### PR TITLE
[deps] Python3 prefers beautifulsoup4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-dateutil
-BeautifulSoup
+beautifulsoup4
 xlrd
 openpyxl


### PR DESCRIPTION
> "You're trying to run a very old release of Beautiful Soup under
Python 3. This will not work."<>"Please use Beautiful Soup 4, available through the pip package 'beautifulsoup4'."